### PR TITLE
NDLサーチをパッケージとして追加

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["biomejs.biome", "streetsidesoftware.code-spell-checker"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "cSpell.ignoreWords": [
+    "AcessRights",
+    "NDLC",
+    "dcndl",
+    "dpid",
+    "mediatype",
+    "rdfs"
+  ]
+}

--- a/packages/ndl-search/package.json
+++ b/packages/ndl-search/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@my-packages/ndl-search",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  }
+}

--- a/packages/ndl-search/package.json
+++ b/packages/ndl-search/package.json
@@ -6,6 +6,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "test": "vitest run",
     "typecheck": "tsc"
   },
   "dependencies": {
@@ -13,6 +14,7 @@
     "zod": "^3.24.3"
   },
   "devDependencies": {
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "^3.1.1"
   }
 }

--- a/packages/ndl-search/package.json
+++ b/packages/ndl-search/package.json
@@ -8,6 +8,9 @@
   "scripts": {
     "typecheck": "tsc"
   },
+  "dependencies": {
+    "zod": "^3.24.3"
+  },
   "devDependencies": {
     "typescript": "catalog:"
   }

--- a/packages/ndl-search/package.json
+++ b/packages/ndl-search/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "fast-xml-parser": "^5.2.0",
     "zod": "^3.24.3"
   },
   "devDependencies": {

--- a/packages/ndl-search/readme.md
+++ b/packages/ndl-search/readme.md
@@ -1,0 +1,13 @@
+# 国立国会図書館のSearch APIをTypeScript化
+NDL search を TypeScript で扱えるようにする。
+資料: https://ndlsearch.ndl.go.jp/help/api/specifications
+
+## 機能
+
+- 検索用API
+  - OpenSearchAPI
+  - ~~OpenURL~~
+  - ~~SRU~~
+- ~~ハーベスト用API~~
+  - ~~OAI-PMH~~
+- ~~書影API~~

--- a/packages/ndl-search/src/index.ts
+++ b/packages/ndl-search/src/index.ts
@@ -1,0 +1,4 @@
+const a = 1;
+const b = 2;
+
+console.log(`${a + b}`);

--- a/packages/ndl-search/src/index.ts
+++ b/packages/ndl-search/src/index.ts
@@ -1,4 +1,7 @@
-const a = 1;
-const b = 2;
-
-console.log(`${a + b}`);
+// Open Search API
+export { OpenSearchAPI } from "./open-search-api";
+export type {
+  NDC,
+  OpenSearchOptions,
+  OpenSearchResponseType,
+} from "./open-search-api/types";

--- a/packages/ndl-search/src/open-search-api/constant.ts
+++ b/packages/ndl-search/src/open-search-api/constant.ts
@@ -1,0 +1,109 @@
+export const OPEN_SEARCH_URL =
+  "https://ndlsearch.ndl.go.jp/api/opensearch" as const;
+
+/**
+ * ## メディアタイプ一覧
+ * @see https://ndlsearch.ndl.go.jp/file/help/api/specifications/ndlsearch_api_ap2_20240401.pdf
+ */
+export const MEDIA_TYPES_INFO = {
+  booklet: { name: "紙", description: "資料形態が”紙”であるメタデータ" },
+  micro: {
+    name: "マイクロ",
+    description: "資料形態が”マイクロ”であるメタデータ",
+  },
+  media: {
+    name: "記録メディア",
+    description: "資料形態が”記録メディア”であるメタデータ",
+  },
+  digital: {
+    name: "デジタル",
+    description: "資料形態が”デジタル”であるメタデータ",
+  },
+  books: { name: "図書", description: "資料種別が”図書”であるメタデータ" },
+  periodicals: {
+    name: "雑誌",
+    description: "資料種別が”雑誌”であるメタデータ",
+  },
+  articles: { name: "記事", description: "資料種別が”記事”であるメタデータ" },
+  newspapers: { name: "新聞", description: "資料種別が”新聞”であるメタデータ" },
+  oldmaterials: {
+    name: "和古書・漢籍",
+    description: "資料種別が”和古書・漢籍”であるメタデータ",
+  },
+  maps: { name: "地図", description: "資料種別が”地図”であるメタデータ" },
+  electronic: {
+    name: "電子資料",
+    description: "資料種別が”電子資料”であるメタデータ",
+  },
+  video: {
+    name: "映像資料",
+    description: "資料種別が”映像資料”であるメタデータ",
+  },
+  audio: {
+    name: "録音資料",
+    description: "資料種別が”録音資料”であるメタデータ",
+  },
+  online: {
+    name: "電子資料・電子雑誌",
+    description: "資料種別が”電子書籍・電子雑誌”であるメタデータ",
+  },
+  doctoral: {
+    name: "博士論文",
+    description: "資料種別が”博士論文”であるメタデータ",
+  },
+  reports: {
+    name: "規格・テクニカルリポート類",
+    description: "資料種別が”規格・テクニカルリポート類”であるメタデータ",
+  },
+  web: {
+    name: "webサイト",
+    description: "資料種別が”webサイト”であるメタデータ",
+  },
+  scores: { name: "楽譜", description: "資料種別が”楽譜”であるメタデータ" },
+  manuscripts: {
+    name: "文書・図像類",
+    description: "資料種別が”文書・図像類”であるメタデータ",
+  },
+  children: {
+    name: "児童書",
+    description: "コレクションが”児童書”であるメタデータ",
+  },
+  repository: {
+    name: "リポジトリ収録資料",
+    description: "コレクションが”リポジトリ収録資料”であるメタデータ",
+  },
+  mina: {
+    name: "障害者（全体）",
+    description: "コレクションが”障害者向け資料”であるメタデータ",
+  },
+  "mina-daisy": {
+    name: "障害者DAISY",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”DAISY”であるメタデータ",
+  },
+  "mina-audio": {
+    name: "録音資料",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”録音資料”であるメタデータ",
+  },
+  "mina-braille": {
+    name: "点字資料",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”点字資料”であるメタデータ",
+  },
+  "mina-text": {
+    name: "テキストデータ",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”テキストデータ”であるメタデータ",
+  },
+  "mina-video": {
+    name: "映像資料",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”映像資料”であるメタデータ",
+  },
+  "mina-booklet": {
+    name: "冊子体資料",
+    description:
+      "コレクションが”障害者向け資料”であり、資料形態が”冊子体資料”であるメタデータ",
+  },
+} as const satisfies Record<string, { name: string; description: string }>;

--- a/packages/ndl-search/src/open-search-api/index.ts
+++ b/packages/ndl-search/src/open-search-api/index.ts
@@ -1,0 +1,23 @@
+import type { OpenSearchOptions, OpenSearchResponseType } from "./types";
+import { parseOpenSearchXml } from "./utils/parse";
+import { buildQuery } from "./utils/query";
+import { validationOpenSearchSchema } from "./utils/validation";
+
+const OPEN_SEARCH_URL = "https://ndlsearch.ndl.go.jp/api/opensearch" as const;
+
+/**
+ * ## Open Search API検索実行
+ * 検索結果のxmlはRSS2.0形式で返却される為、それに準拠したパースを行う。
+ */
+export const OpenSearchAPI = async (
+  options: OpenSearchOptions,
+): Promise<OpenSearchResponseType> => {
+  const query = buildQuery(options);
+  const req = `${OPEN_SEARCH_URL}?${query}`;
+
+  const res = await fetch(req);
+  const xml = await res.text();
+
+  const parsedObj = parseOpenSearchXml(xml);
+  return validationOpenSearchSchema(parsedObj);
+};

--- a/packages/ndl-search/src/open-search-api/schema.ts
+++ b/packages/ndl-search/src/open-search-api/schema.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+const openSearchDcIdentifierSchema = z.object({
+  "#text": z.union([z.string(), z.number()]),
+  "@_xsi:type": z.string(),
+});
+
+const openSearchRdfSeeAlsoSchema = z.object({
+  "@_rdf:resource": z.string(),
+});
+
+const openSearchItemSchema = z.object({
+  title: z.string(),
+  link: z.string(),
+  description: z.string(),
+  author: z.string(),
+  category: z.union([z.string(), z.array(z.string())]),
+  "dc:title": z.string(),
+  "dc:creator": z.union([z.string(), z.array(z.string())]).optional(),
+  "dcndl:volume": z.number().optional(),
+  "dc:publisher": z.union([z.string(), z.array(z.string())]).optional(),
+  "dc:identifier": z
+    .union([
+      openSearchDcIdentifierSchema,
+      z.array(openSearchDcIdentifierSchema),
+    ])
+    .optional(),
+  "rdfs:seeAlso": z
+    .union([openSearchRdfSeeAlsoSchema, z.array(openSearchRdfSeeAlsoSchema)])
+    .optional(),
+});
+
+export const openSearchResponseSchema = z.object({
+  rss: z.object({
+    channel: z.object({
+      title: z.string(),
+      item: z.union([openSearchItemSchema, z.array(openSearchItemSchema)]),
+      description: z.string(),
+      language: z.string(),
+      link: z.string(),
+      "openSearch:totalResults": z.number(),
+      "openSearch:startIndex": z.number(),
+      "openSearch:itemsPerPage": z.number(),
+    }),
+  }),
+});

--- a/packages/ndl-search/src/open-search-api/types.ts
+++ b/packages/ndl-search/src/open-search-api/types.ts
@@ -1,0 +1,68 @@
+import type { z } from "zod";
+import type { MEDIA_TYPES_INFO } from "./constant";
+import type { openSearchResponseSchema } from "./schema";
+
+export type MediaType = keyof typeof MEDIA_TYPES_INFO;
+
+/**
+ * ## NDC(書籍分類)
+ * @see https://www.library.metro.tokyo.lg.jp/support_school/research/for_study/report_guide/tool/ndc/index.html
+ */
+export enum NDC {
+  /** 総記 */
+  GeneralWorks = 0,
+  /** 哲学 */
+  Philosophy = 1,
+  /** 歴史 */
+  History = 2,
+  /** 社会科学 */
+  SocialSciences = 3,
+  /** 自然科学 */
+  NaturalSciences = 4,
+  /** 技術 */
+  Technology = 5,
+  /** 産業 */
+  Industry = 6,
+  /** 芸術 */
+  Arts = 7,
+  /** 言語 */
+  Language = 8,
+  /** 文学 */
+  Literature = 9,
+}
+
+/**
+ * ## Open Search API - 検索オプション
+ * 外部提供インタフェース仕様書の12P参照
+ * @see https://ndlsearch.ndl.go.jp/file/help/api/specifications/ndlsearch_api_20240712.pdf
+ */
+export interface OpenSearchOptions {
+  /** データプロバイダID, データグループID, コレクションコード, AcessRights */
+  dpid?: string | string[];
+  /** すべての項目を対象に検索 */
+  any?: string;
+  /** タイトル(部分一致・複数可) */
+  title?: string | string[];
+  /** 作成者(部分一致・複数可) */
+  creator?: string | string[];
+  /** 出版者(部分一致・複数可) */
+  publisher?: string | string[];
+  /** デジタル化した製作者(部分一致・複数可) */
+  digitizedPublisher?: string | string[];
+  /** 分類(NDC, NDLC)(前方一致) */
+  ndc?: NDC;
+  /** 開始出版年月日 */
+  from?: Date;
+  /** 終了出版年月日 */
+  until?: Date;
+  /** 出力レコード上限値（省略時は200とする。max=500） */
+  cnt?: number;
+  /** レコード取得開始位置（省略時は1とする）  */
+  idx?: number;
+  /** ISBN(完全一致または前方一致) */
+  isbn?: string;
+  /** メディアタイプ(完全一致・複数可) */
+  mediatype?: MediaType | MediaType[];
+}
+
+export type OpenSearchResponseType = z.infer<typeof openSearchResponseSchema>;

--- a/packages/ndl-search/src/open-search-api/utils/parse.ts
+++ b/packages/ndl-search/src/open-search-api/utils/parse.ts
@@ -1,0 +1,18 @@
+import { XMLParser } from "fast-xml-parser";
+
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  trimValues: true,
+  parseAttributeValue: true,
+  numberParseOptions: {
+    hex: false,
+    leadingZeros: false,
+  },
+});
+
+/**
+ * ### NDL API (OpenSearch) のレスポンスをパース
+ * xmlはRSS2.0形式で返却される為、それに準拠したパースを行う。
+ * @see https://hail2u.net/documents/rss20notes.html#channel_element
+ */
+export const parseOpenSearchXml = (xml: string) => xmlParser.parse(xml);

--- a/packages/ndl-search/src/open-search-api/utils/query.test.ts
+++ b/packages/ndl-search/src/open-search-api/utils/query.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+import { NDC, type OpenSearchOptions } from "../types";
+import { buildQuery } from "./query";
+
+type TestPattern = {
+  patternName: string;
+  propsPattern: OpenSearchOptions;
+  expected: string;
+};
+
+// 一旦、公式で紹介されているURLを生成できることを確認する
+const testPatterns = [
+  {
+    patternName: "タイトルだけのクエリ",
+    propsPattern: { title: "夏目漱石" },
+    expected: "title=%E5%A4%8F%E7%9B%AE%E6%BC%B1%E7%9F%B3",
+  },
+  {
+    patternName: "日付だけのクエリ",
+    propsPattern: { until: new Date("2024/01/01") },
+    expected: "until=2024-01-01",
+  },
+  {
+    patternName: "タイトルを複数指定したクエリ",
+    propsPattern: { title: ["夏目漱石", "マリーアントワネット"] },
+    expected:
+      "title=%E5%A4%8F%E7%9B%AE%E6%BC%B1%E7%9F%B3&title=%E3%83%9E%E3%83%AA%E3%83%BC%E3%82%A2%E3%83%B3%E3%83%88%E3%83%AF%E3%83%8D%E3%83%83%E3%83%88",
+  },
+  {
+    patternName:
+      "タイトルに「マリーアントワネット」を含み、かつ分類（NDC）が「2（歴史）」",
+    propsPattern: {
+      cnt: 10,
+      title: "マリーアントワネット",
+      ndc: NDC.History,
+    },
+    expected:
+      "cnt=10&title=%E3%83%9E%E3%83%AA%E3%83%BC%E3%82%A2%E3%83%B3%E3%83%88%E3%83%AF%E3%83%8D%E3%83%83%E3%83%88&ndc=2",
+  },
+] as const satisfies TestPattern[];
+
+describe("BuildQuery()", () => {
+  test.each(testPatterns)(
+    "正常系: $patternName",
+    ({ propsPattern, expected }) => {
+      expect(buildQuery(propsPattern)).toEqual(expected);
+    },
+  );
+});

--- a/packages/ndl-search/src/open-search-api/utils/query.ts
+++ b/packages/ndl-search/src/open-search-api/utils/query.ts
@@ -1,0 +1,50 @@
+import type { OpenSearchOptions } from "../types";
+
+const isString = (value: unknown): value is string => {
+  return typeof value === "string";
+};
+
+const isNumber = (value: unknown): value is number => {
+  return typeof value === "number";
+};
+
+const formatDate = (date: Date): string => {
+  return date
+    .toLocaleDateString("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    })
+    .replaceAll("/", "-");
+};
+
+/**
+ * ## NLD検索クエリ作成
+ */
+export const buildQuery = (options: OpenSearchOptions): string => {
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(options)) {
+    if (isString(value)) {
+      searchParams.append(key, value);
+    }
+
+    if (isNumber(value)) {
+      searchParams.append(key, String(value));
+    }
+
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        if (isString(v)) {
+          searchParams.append(key, v);
+        }
+      }
+    }
+
+    if (value instanceof Date) {
+      searchParams.append(key, formatDate(value));
+    }
+  }
+
+  return searchParams.toString();
+};

--- a/packages/ndl-search/src/open-search-api/utils/validation.ts
+++ b/packages/ndl-search/src/open-search-api/utils/validation.ts
@@ -1,0 +1,12 @@
+import { openSearchResponseSchema } from "../schema";
+import type { OpenSearchResponseType } from "../types";
+
+/**
+ * ### パースされたオブジェクトをバリデーションする
+ * @return OpenSearchResponseType
+ */
+export const validationOpenSearchSchema = (
+  xml: unknown,
+): OpenSearchResponseType => {
+  return openSearchResponseSchema.parse(xml);
+};

--- a/packages/ndl-search/tsconfig.json
+++ b/packages/ndl-search/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "incremental": false,
+    "resolveJsonModule": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
+      vitest:
+        specifier: ^3.1.1
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1)
 
 packages:
 
@@ -1010,6 +1013,35 @@ packages:
   '@vanilla-extract/private@1.0.6':
     resolution: {integrity: sha512-ytsG/JLweEjw7DBuZ/0JCN4WAQgM9erfSTdS1NQY778hFQSZ6cfCDEZZ0sgVm4k54uNz6ImKB33AYvSR//fjxw==}
 
+  '@vitest/expect@3.1.1':
+    resolution: {integrity: sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==}
+
+  '@vitest/mocker@3.1.1':
+    resolution: {integrity: sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.1.1':
+    resolution: {integrity: sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==}
+
+  '@vitest/runner@3.1.1':
+    resolution: {integrity: sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==}
+
+  '@vitest/snapshot@3.1.1':
+    resolution: {integrity: sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==}
+
+  '@vitest/spy@3.1.1':
+    resolution: {integrity: sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==}
+
+  '@vitest/utils@3.1.1':
+    resolution: {integrity: sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==}
+
   '@web3-storage/multipart-parser@1.0.0':
     resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
 
@@ -1069,6 +1101,10 @@ packages:
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -1164,6 +1200,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
+    engines: {node: '>=12'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1179,6 +1219,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1311,6 +1355,10 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-object-diff@1.1.9:
     resolution: {integrity: sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==}
@@ -1475,6 +1523,10 @@ packages:
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
+
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+    engines: {node: '>=12.0.0'}
 
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
@@ -1860,6 +1912,9 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -1869,6 +1924,9 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   markdown-extensions@1.1.1:
     resolution: {integrity: sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==}
@@ -2253,6 +2311,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
+
   peek-stream@1.1.3:
     resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
 
@@ -2597,6 +2659,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2638,9 +2703,15 @@ packages:
     resolution: {integrity: sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
@@ -2729,9 +2800,27 @@ packages:
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.12:
     resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2888,6 +2977,11 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite-node@3.1.1:
+    resolution: {integrity: sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-tsconfig-paths@4.3.2:
     resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
     peerDependencies:
@@ -2967,6 +3061,34 @@ packages:
       yaml:
         optional: true
 
+  vitest@3.1.1:
+    resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.1.1
+      '@vitest/ui': 3.1.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -2989,6 +3111,11 @@ packages:
   which@3.0.1:
     resolution: {integrity: sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -3909,6 +4036,46 @@ snapshots:
 
   '@vanilla-extract/private@1.0.6': {}
 
+  '@vitest/expect@3.1.1':
+    dependencies:
+      '@vitest/spy': 3.1.1
+      '@vitest/utils': 3.1.1
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.1.1(vite@6.3.2(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))':
+    dependencies:
+      '@vitest/spy': 3.1.1
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.3.2(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1)
+
+  '@vitest/pretty-format@3.1.1':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.1.1':
+    dependencies:
+      '@vitest/utils': 3.1.1
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.1.1':
+    dependencies:
+      '@vitest/pretty-format': 3.1.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.1.1':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@3.1.1':
+    dependencies:
+      '@vitest/pretty-format': 3.1.1
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
+
   '@web3-storage/multipart-parser@1.0.0': {}
 
   '@zxing/text-encoding@0.9.0':
@@ -3956,6 +4123,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-flatten@1.1.1: {}
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -4076,6 +4245,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.2.0:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.3
+      pathval: 2.0.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4088,6 +4265,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -4190,6 +4369,8 @@ snapshots:
       character-entities: 2.0.2
 
   dedent@1.5.3: {}
+
+  deep-eql@5.0.2: {}
 
   deep-object-diff@1.1.9: {}
 
@@ -4407,6 +4588,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   exit-hook@2.2.1: {}
+
+  expect-type@1.2.1: {}
 
   express@4.21.2:
     dependencies:
@@ -4804,6 +4987,8 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  loupe@3.1.3: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -4811,6 +4996,10 @@ snapshots:
       yallist: 3.1.1
 
   lru-cache@7.18.3: {}
+
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   markdown-extensions@1.1.1: {}
 
@@ -5363,6 +5552,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.0: {}
+
   peek-stream@1.1.3:
     dependencies:
       buffer-from: 1.1.2
@@ -5765,6 +5956,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -5800,7 +5993,11 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  stackback@0.0.2: {}
+
   statuses@2.0.1: {}
+
+  std-env@3.9.0: {}
 
   stream-shift@1.0.3: {}
 
@@ -5931,10 +6128,20 @@ snapshots:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.12:
     dependencies:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinypool@1.0.2: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6120,6 +6327,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.1.1(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.3
+      vite: 6.3.2(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-tsconfig-paths@4.3.2(typescript@5.8.3)(vite@6.3.2(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1)):
     dependencies:
       debug: 4.4.0
@@ -6154,6 +6382,45 @@ snapshots:
       jiti: 1.21.7
       yaml: 2.7.1
 
+  vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1):
+    dependencies:
+      '@vitest/expect': 3.1.1
+      '@vitest/mocker': 3.1.1(vite@6.3.2(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))
+      '@vitest/pretty-format': 3.1.1
+      '@vitest/runner': 3.1.1
+      '@vitest/snapshot': 3.1.1
+      '@vitest/spy': 3.1.1
+      '@vitest/utils': 3.1.1
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.3.2(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1)
+      vite-node: 3.1.1(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.14.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -6183,6 +6450,11 @@ snapshots:
   which@3.0.1:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,10 @@ importers:
         version: 4.3.2(typescript@5.8.3)(vite@6.3.2(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))
 
   packages/ndl-search:
+    dependencies:
+      zod:
+        specifier: ^3.24.3
+        version: 3.24.3
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -3018,6 +3022,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.24.3:
+    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -6186,5 +6193,7 @@ snapshots:
   yaml@2.7.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.24.3: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
 
   packages/ndl-search:
     dependencies:
+      fast-xml-parser:
+        specifier: ^5.2.0
+        version: 5.2.0
       zod:
         specifier: ^3.24.3
         version: 3.24.3
@@ -1487,6 +1490,10 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-xml-parser@5.2.0:
+    resolution: {integrity: sha512-Uw9+Mjt4SBRud1IcaYuW/O0lW8SKKdMl5g7g24HiIuyH5fQSD+AVLybSlJtqLYEbytVFjWQa5DMGcNgeksdRBg==}
+    hasBin: true
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2676,6 +2683,9 @@ packages:
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+
+  strnum@2.0.5:
+    resolution: {integrity: sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q==}
 
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
@@ -4446,6 +4456,10 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-xml-parser@5.2.0:
+    dependencies:
+      strnum: 2.0.5
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -5830,6 +5844,8 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-final-newline@2.0.0: {}
+
+  strnum@2.0.5: {}
 
   style-to-object@0.4.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,12 @@ importers:
         specifier: ^4.2.1
         version: 4.3.2(typescript@5.8.3)(vite@6.3.2(@types/node@22.14.1)(jiti@1.21.7)(yaml@2.7.1))
 
+  packages/ndl-search:
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
 packages:
 
   '@alloc/quick-lru@5.2.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "app"
+  - "packages/*"
 
 catalog:
   typescript: ^5.8.3


### PR DESCRIPTION
## 概要
国立国会図書館の検索APIをTypeScriptで使えるようにした。

- NDL Searchをパッケージとして追加
- 独自の単語を持つ為、`code-spell-checker`の単語除外リストを作成
  - 上記に伴いvscodeのおすすめ拡張機能を追加