### PR TITLE
BookUseCasesにメソッド追加

### DIFF
--- a/core/entities/src/book/entity.ts
+++ b/core/entities/src/book/entity.ts
@@ -4,8 +4,7 @@ import type { Book } from "./types";
 
 export interface BookRepository {
   findById(id: string): Promise<BookEntity | undefined>;
-  findAll(volume?: number): Promise<BookEntity[]>;
-  findByTitle(title: string): Promise<BookEntity | undefined>;
+  findAll(volume?: number, offset?: number): Promise<BookEntity[]>;
   findByISBN(isbn: string): Promise<BookEntity | undefined>;
 }
 

--- a/core/use-cases/package.json
+++ b/core/use-cases/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@my-packages/utils": "workspace:*",
     "@core/entities": "workspace:*"
   },
   "devDependencies": {

--- a/core/use-cases/src/__fixtures__/mock-books.ts
+++ b/core/use-cases/src/__fixtures__/mock-books.ts
@@ -1,0 +1,23 @@
+import { BookEntity } from "@core/entities";
+
+export const mockBooks = Array<number>(20).map((value) => {
+  return new BookEntity({
+    id: `mock-book-${value}`,
+    props: {
+      title: `Test Book ${value}`,
+      description: "Test Description",
+      author: ["Test Author"],
+      category: ["Test Category"],
+    },
+  });
+});
+
+export const mockBookEntity = new BookEntity({
+  id: "1",
+  props: {
+    title: "Test Book",
+    description: "Test Description",
+    author: ["Test Author"],
+    category: ["Test Category"],
+  },
+});

--- a/core/use-cases/src/book/use-cases.test.ts
+++ b/core/use-cases/src/book/use-cases.test.ts
@@ -1,33 +1,51 @@
-import { BookEntity, type BookRepository } from "@core/entities";
+import type { BookRepository } from "@core/entities";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockBookEntity, mockBooks } from "../__fixtures__/mock-books";
 import { BookUseCases } from "./use-cases";
 
 const mockRepository: BookRepository = {
   findById: vi.fn(),
   findAll: vi.fn(),
-  findByTitle: vi.fn(),
   findByISBN: vi.fn(),
 };
-
-const mockBookEntity = new BookEntity({
-  id: "1",
-  props: {
-    title: "Test Book",
-    description: "Test Description",
-    author: ["Test Author"],
-    category: ["Test Category"],
-  },
-});
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.resetAllMocks();
 });
 
-describe("BookUseCases", () => {
-  const bookUseCases = new BookUseCases(mockRepository);
+const bookUseCases = new BookUseCases(mockRepository);
 
-  it("should return a book when found by ID", async () => {
+describe("findAll()", () => {
+  it("書籍のリストを返すべき", async () => {
+    vi.spyOn(mockRepository, "findAll").mockResolvedValue(mockBooks);
+    const result = await bookUseCases.getBooks(20, 0);
+
+    expect(mockRepository.findAll).toHaveBeenCalledWith(20, 0);
+    expect(result).not.toBeUndefined();
+    expect(result).toEqual(mockBooks.map((book) => book.freeze()));
+  });
+});
+
+describe("findByISBN()", () => {
+  it("正常なISBNなら書籍を返す", async () => {
+    vi.spyOn(mockRepository, "findByISBN").mockResolvedValue(mockBookEntity);
+    const result = await bookUseCases.getBookByISBN("9784798163502");
+
+    expect(mockRepository.findByISBN).toHaveBeenCalledWith("9784798163502");
+    expect(result).not.toBeUndefined();
+  });
+  it("ISBNでなかったらrepositoryにリクエストする前にundefinedを返す", async () => {
+    vi.spyOn(mockRepository, "findByISBN").mockResolvedValue(mockBookEntity);
+    const result = await bookUseCases.getBookByISBN("978-4-04-893065-9");
+
+    expect(mockRepository.findByISBN).toHaveBeenCalledTimes(0);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("findById()", () => {
+  it("IDで見つかったら書籍を返す", async () => {
     vi.spyOn(mockRepository, "findById").mockResolvedValue(mockBookEntity);
     const result = await bookUseCases.getBookById("1");
 
@@ -35,8 +53,7 @@ describe("BookUseCases", () => {
     expect(result).not.toBeUndefined();
     expect(result).toEqual(mockBookEntity.freeze());
   });
-
-  it("should throw undefined when book is not found", async () => {
+  it("書籍が見つからない場合undefinedを投げる", async () => {
     vi.spyOn(mockRepository, "findById").mockResolvedValue(undefined);
     const result = await bookUseCases.getBookById("2");
 

--- a/core/use-cases/src/book/use-cases.ts
+++ b/core/use-cases/src/book/use-cases.ts
@@ -1,10 +1,43 @@
 import type { BookObject, BookRepository } from "@core/entities";
+import { isISBN } from "@my-packages/utils";
 
 export class BookUseCases {
   constructor(private repository: BookRepository) {}
 
   async getBookById(id: string): Promise<BookObject | undefined> {
     const book = await this.repository.findById(id);
+    if (!book) {
+      return undefined;
+    }
+    return book.freeze();
+  }
+
+  /**
+   * 書籍一覧を取得する
+   * @param volume 取得する書籍の数(default: 20)
+   * @param offset 取得する書籍のオフセット
+   * @returns 書籍一覧
+   */
+  async getBooks(
+    volume: number = 20,
+    offset: number = 0,
+  ): Promise<BookObject[]> {
+    const books = await this.repository.findAll(volume, offset);
+    return books.map((book) => book.freeze());
+  }
+
+  /**
+   * ISBNから書籍を取得する
+   * @param isbn 書籍のISBN
+   * @returns 書籍情報
+   */
+  async getBookByISBN(isbn: string): Promise<BookObject | undefined> {
+    if (!isISBN(isbn)) {
+      // console.error("Invalid ISBN format");
+      return undefined;
+    }
+
+    const book = await this.repository.findByISBN(isbn);
     if (!book) {
       return undefined;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@core/entities':
         specifier: workspace:*
         version: link:../entities
+      '@my-packages/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
     devDependencies:
       '@my-configs/typescript':
         specifier: workspace:*


### PR DESCRIPTION
## 概要
- 書籍リストを取得するメソッドを追加
- ISBNで検索するメソッドを追加

### 備考
Repositoryインターフェースの破壊的変更(プロパティ削除)を行っているが、実装はないので外部への影響はなし。