### PR TITLE
BookEntityロジックの詳細を追加

### DIFF
--- a/core/entities/package.json
+++ b/core/entities/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "isbn3": "^1.2.10",
     "uuid": "^10.0.0"
   },
   "devDependencies": {

--- a/core/entities/src/base-repository.ts
+++ b/core/entities/src/base-repository.ts
@@ -1,0 +1,7 @@
+export interface BaseRepository<T> {
+  add(entity: T): Promise<void>;
+  update(entity: T): Promise<void>;
+  remove(id: string): Promise<void>;
+  findById(id: string): Promise<T | undefined>;
+  findAll(volume?: number, offset?: number): Promise<T[]>;
+}

--- a/core/entities/src/book/entity.test.ts
+++ b/core/entities/src/book/entity.test.ts
@@ -3,15 +3,30 @@ import { BookEntity } from "./entity";
 import type { Book } from "./types";
 
 describe("BookEntity()", () => {
-  test("新規追加", () => {
+  test("正常系: 新規追加", () => {
     const mockProps: Book = {
-      title: "本の題名",
-      description: "概要",
-      author: [],
-      category: [],
+      isbn: "９78-4-04-８93065-９",
+      title: "Clean Architecture : 達人に学ぶソフトウェアの構造と設計",
+      description: "ｶﾞｲﾖｳﾗﾝ",
+      authors: [],
+      categories: [],
     };
 
     const book = BookEntity.create(mockProps);
-    expect(book.freeze().title).toEqual("本の題名");
+    expect(book.freeze().isbn).toEqual("9784048930659");
+    expect(book.freeze().description).toEqual("ｶﾞｲﾖｳﾗﾝ");
+  });
+  test("異常系: 新規追加", () => {
+    const mockProps: Book = {
+      isbn: "not an isbn",
+      title: "存在しない本の題名",
+      description: "ｶﾞｲﾖｳﾗﾝ",
+      authors: [],
+      categories: [],
+    };
+
+    expect(() => {
+      BookEntity.create(mockProps);
+    }).toThrowError("Invalid ISBN");
   });
 });

--- a/core/entities/src/book/entity.ts
+++ b/core/entities/src/book/entity.ts
@@ -1,20 +1,90 @@
+import { parse as isbnParser } from "isbn3";
 import { v4 as uuidv4 } from "uuid";
 import { BaseEntity } from "../base-entity";
-import type { Book } from "./types";
+import type { BaseRepository } from "../base-repository";
+import type { Author, Book, Category, InitBookProps } from "./types";
 
-export interface BookRepository {
-  findById(id: string): Promise<BookEntity | undefined>;
-  findAll(volume?: number, offset?: number): Promise<BookEntity[]>;
+export interface BookRepository extends BaseRepository<BookEntity> {
   findByISBN(isbn: string): Promise<BookEntity | undefined>;
 }
 
-// ToDo: 作成しながら拡張していく。
 export class BookEntity extends BaseEntity<Book> {
+  constructor(info: InitBookProps) {
+    const normalizedISBN = info.props.isbn.normalize("NFKC");
+    const parsedISBN = isbnParser(normalizedISBN);
+    if (!parsedISBN) {
+      throw new Error("Invalid ISBN");
+    }
+
+    const isbn = parsedISBN.isbn13 || parsedISBN.isbn10 || "";
+    const title = info.props.title;
+    const description = info.props.description;
+    const categories = info.props.categories.map(
+      (category) => new CategoryEntity(category),
+    );
+    const authors = info.props.authors.map(
+      (author) => new AuthorEntity(author),
+    );
+
+    super({
+      ...info,
+      props: {
+        isbn,
+        title,
+        description,
+        authors,
+        categories,
+      },
+      createdAt: info.createdAt,
+      updatedAt: info.updatedAt,
+    });
+  }
+
   /**
    * Entityの新規作成時に利用
    */
-  static create(props: Book): BookEntity {
+  static create(book: Book): BookEntity {
     const id = uuidv4();
-    return new BookEntity({ id, props });
+    return new BookEntity({
+      id,
+      props: book,
+    });
+  }
+
+  static isISBN(isbn: string): boolean {
+    const parsedISBN = isbnParser(isbn);
+    return !!parsedISBN;
+  }
+}
+
+/**
+ * ### カテゴリに関するロジックをまとめたクラス
+ * BookEntityからのみ利用される
+ */
+class CategoryEntity implements Category {
+  readonly id: number;
+  readonly name: string;
+  readonly label?: string;
+
+  constructor(category: Category) {
+    this.id = category.id;
+    this.name = category.name.normalize("NFKC");
+    this.label = category.label?.normalize("NFKC");
+  }
+}
+
+/**
+ * ### 著者に関するロジックをまとめたクラス
+ * BookEntityからのみ利用される
+ */
+class AuthorEntity implements Author {
+  readonly id: number;
+  readonly name: string;
+  readonly kana: string;
+
+  constructor(author: Author) {
+    this.id = author.id;
+    this.name = author.name.normalize("NFKC");
+    this.kana = author.kana.normalize("NFKC");
   }
 }

--- a/core/entities/src/book/types.ts
+++ b/core/entities/src/book/types.ts
@@ -1,10 +1,21 @@
 import type { BaseEntityProps, BaseObject } from "../base-entity";
 
+export type Category = {
+  id: number;
+  name: string;
+  label?: string;
+};
+export type Author = {
+  id: number;
+  name: string;
+  kana: string;
+};
 export type Book = {
+  isbn: string;
   title: string;
   description: string;
-  author: string[];
-  category: string[];
+  authors: Author[];
+  categories: Category[];
 };
 export type BookObject = Readonly<BaseObject<Book>>;
 export type InitBookProps = BaseEntityProps<Book>;

--- a/core/use-cases/src/__fixtures__/mock-books.ts
+++ b/core/use-cases/src/__fixtures__/mock-books.ts
@@ -4,10 +4,11 @@ export const mockBooks = Array<number>(20).map((value) => {
   return new BookEntity({
     id: `mock-book-${value}`,
     props: {
+      isbn: `40887429${value}`,
       title: `Test Book ${value}`,
       description: "Test Description",
-      author: ["Test Author"],
-      category: ["Test Category"],
+      authors: [],
+      categories: [],
     },
   });
 });
@@ -15,9 +16,10 @@ export const mockBooks = Array<number>(20).map((value) => {
 export const mockBookEntity = new BookEntity({
   id: "1",
   props: {
-    title: "Test Book",
+    isbn: "4-08-874291-5",
+    title: "魔人探偵脳噛ネウロ",
     description: "Test Description",
-    author: ["Test Author"],
-    category: ["Test Category"],
+    authors: [],
+    categories: [],
   },
 });

--- a/core/use-cases/src/book/use-cases.test.ts
+++ b/core/use-cases/src/book/use-cases.test.ts
@@ -4,6 +4,9 @@ import { mockBookEntity, mockBooks } from "../__fixtures__/mock-books";
 import { BookUseCases } from "./use-cases";
 
 const mockRepository: BookRepository = {
+  add: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
   findById: vi.fn(),
   findAll: vi.fn(),
   findByISBN: vi.fn(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
 
   core/entities:
     dependencies:
+      isbn3:
+        specifier: ^1.2.10
+        version: 1.2.10
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -1892,6 +1895,11 @@ packages:
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isbn3@1.2.10:
+    resolution: {integrity: sha512-JWzRvXxK9fIXgoLAAedKMXNF8mlbwNiGENyhbZR5ECdsq3tKl8ifdtLQ5R8WQzynFESTdnfbSHfrxr9cbjbgQA==}
+    engines: {node: '>= 6.4.0'}
+    hasBin: true
 
   isbot@4.4.0:
     resolution: {integrity: sha512-8ZvOWUA68kyJO4hHJdWjyreq7TYNWTS9y15IzeqVdKxR9pPr3P/3r9AHcoIv9M0Rllkao5qWz2v1lmcyKIVCzQ==}
@@ -4990,6 +4998,8 @@ snapshots:
   is-unicode-supported@0.1.0: {}
 
   isarray@1.0.0: {}
+
+  isbn3@1.2.10: {}
 
   isbot@4.4.0: {}
 


### PR DESCRIPTION
## 概要
タイトルの通り。
ISBNをパース実装するのは面倒なので、外部パッケージの`isbn3`を利用。