### PR TITLE
biomeのリンタールールを追加

### DIFF
--- a/app/app/entry.server.tsx
+++ b/app/app/entry.server.tsx
@@ -39,12 +39,12 @@ export default function handleRequest(
       );
 }
 
-function handleBotRequest(
+const handleBotRequest = (
   request: Request,
   responseStatusCode: number,
   responseHeaders: Headers,
   remixContext: EntryContext,
-) {
+) => {
   return new Promise((resolve, reject) => {
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
@@ -87,14 +87,14 @@ function handleBotRequest(
 
     setTimeout(abort, ABORT_DELAY);
   });
-}
+};
 
-function handleBrowserRequest(
+const handleBrowserRequest = (
   request: Request,
   responseStatusCode: number,
   responseHeaders: Headers,
   remixContext: EntryContext,
-) {
+) => {
   return new Promise((resolve, reject) => {
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
@@ -137,4 +137,4 @@ function handleBrowserRequest(
 
     setTimeout(abort, ABORT_DELAY);
   });
-}
+};

--- a/app/app/root.tsx
+++ b/app/app/root.tsx
@@ -22,7 +22,7 @@ export const links: LinksFunction = () => [
   },
 ];
 
-export function Layout({ children }: { children: React.ReactNode }) {
+export const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="en">
       <head>
@@ -38,7 +38,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       </body>
     </html>
   );
-}
+};
 
 export default function App() {
   return <Outlet />;

--- a/biome.json
+++ b/biome.json
@@ -23,5 +23,6 @@
         "useImportType": "error"
       }
     }
-  }
+  },
+  "plugins": ["./plugins/no-fn-decl.grit"]
 }

--- a/plugins/no-fn-decl.grit
+++ b/plugins/no-fn-decl.grit
@@ -1,0 +1,5 @@
+language js
+
+`function $name($params) { $body }` where {
+  register_diagnostic(span=$name, message="関数宣言ではなく、`const $name = ($params) => {}` を使ってください")
+}


### PR DESCRIPTION
## 概要
"function"の利用を禁止してアロー関数を使うように促すリンタールールを追加。
参考: https://biomejs.dev/linter/plugins/

### 実装背景
biomeのベータ版からリンタープラグインを追加できるようになったので、実験で入れてみようかなと考えて作ってみた。
個人的にjsではfunctionを使わない書き方が好きなので原則禁止とする。
